### PR TITLE
Work around globbing issue in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.defaultFormatter": "vscode.json-language-features"
   },
   "files.associations": {
-    "**/{{ cookiecutter.project_slug }}/**/*.py": "jinja-py",
+    "**/?? cookiecutter.project_slug ??/**/*.py": "jinja-py",
     "**/hooks/*_gen_project.py": "jinja-py"
   },
   "files.exclude": {


### PR DESCRIPTION
Presently, curly braces cannot be used in globs because [they have
a special meaning in VS Code’s globber and there’s no way to escape
them](https://github.com/microsoft/vscode/blob/dbae720630e5996cc4d05c14649480a19b077d78/src/vs/base/common/glob.ts#L79-L92
).

Work around that limitation by globbing out the curly braces.
