### PR TITLE
Bump versions

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -23,6 +23,8 @@ os.unlink('{{ cookiecutter.project_slug }}/fire_workarounds.py')
 poetry_environment = os.environ.copy()
 poetry_environment.update({
     'LANG': poetry_environment.get('LANG', 'en_US.UTF-8'),
+    # https://github.com/python-poetry/poetry/issues/1917
+    'PYTHON_KEYRING_BACKEND': 'keyring.backends.null.Keyring',
 })
 
 print('Running poetry. This may take a while.')

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -29,10 +29,10 @@ autopep8 = "*"
 {%- if cookiecutter.use_jupyter == "y" %}
 ipykernel = "*"
 {%- endif %}
-mypy = "~=0.971"
-pdoc = "~=12.1"
+mypy = "~=0.982"
+pdoc = "~=12.2"
 poethepoet = "~=0.16"
-pylint = "~=2.14"
+pylint = "~=2.15"
 pytest = "*"
 {%- if cookiecutter.use_fire == "y" %}
 types-colorama = "*"

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.1.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
@@ -24,7 +24,7 @@ fire = "*"
 pandas = "*"
 {%- endif %}
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 autopep8 = "*"
 {%- if cookiecutter.use_jupyter == "y" %}
 ipykernel = "*"


### PR DESCRIPTION
- poetry: use dependency groups, require core v1.1.0
- Bump dependency versions
- Work around Poetry’s keyring issue
