### PR TITLE
VS Code: remove obsolete workarounds

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -5,16 +5,6 @@ import subprocess
 
 shutil.rmtree('licenses')
 
-# Pick platform-dependent pylint shim
-with open('.vscode/settings.json', 'r+') as file:
-    content = file.read()
-    file.seek(0)
-    file.write(content.replace(
-        '.SHIM_EXT',
-        '.bat' if platform.system() == 'Windows' else '',
-    ))
-    file.truncate()
-
 {%- if cookiecutter.use_fire != "y" %}
 os.unlink('{{ cookiecutter.project_slug }}/fire_workarounds.py')
 {%- endif %}

--- a/{{ cookiecutter.project_slug }}/.shims/.editorconfig
+++ b/{{ cookiecutter.project_slug }}/.shims/.editorconfig
@@ -1,9 +1,0 @@
-# https://editorconfig.org
-
-root = false
-
-[*]
-end_of_line = lf
-
-[*.bat]
-end_of_line = crlf

--- a/{{ cookiecutter.project_slug }}/.shims/pylint
+++ b/{{ cookiecutter.project_slug }}/.shims/pylint
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-exec poetry run python -m "${0##*/}" "$@"

--- a/{{ cookiecutter.project_slug }}/.shims/pylint.bat
+++ b/{{ cookiecutter.project_slug }}/.shims/pylint.bat
@@ -1,1 +1,0 @@
-@poetry run python -m pylint %*

--- a/{{ cookiecutter.project_slug }}/.vscode/settings.json
+++ b/{{ cookiecutter.project_slug }}/.vscode/settings.json
@@ -27,13 +27,12 @@
     "**/*.egg-info": true,
     "**/__pycache__": true
   },
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/",
   "python.linting.pylintArgs": [
     "--enable-all-extensions"
   ],
   "python.linting.pylintCategorySeverity.refactor": "Warning",
   "python.linting.pylintEnabled": true,
-  "python.linting.pylintPath": "${workspaceFolder}/.shims/pylint.SHIM_EXT",
+  "python.linting.pylintPath": "pylint",
   "python.testing.pytestArgs": [
     "tests"
   ],


### PR DESCRIPTION
Remove workarounds which no longer work with current versions of
VS Code’s Python extension (starting with version 2022.18.1).

From that version on, those workarounds are no longer necessary
anyway. The Python extension now appears to detect the venv’s
interpreter automatically and then switch to it.
